### PR TITLE
Feature/wait for migration

### DIFF
--- a/process.py
+++ b/process.py
@@ -105,7 +105,7 @@ def execute(api, entry, cfg, import_dir):
         raise ValueError("Unknown action: %s" % action)
 
 
-def wait_for_server(api, delay=90, timeout=900):
+def wait_for_server(api, delay=90, timeout=900, attempts=2, migration_delay=1500):
     "Sleep until server is ready to accept requests"
     debug("Check active API: %s" % api.api_url)
     time.sleep(delay)  # in case tomcat is still starting
@@ -114,6 +114,12 @@ def wait_for_server(api, delay=90, timeout=900):
         try:
             api.get("/me")
             break
+        except requests.exceptions.HTTPError:
+            if attempts > 0:
+                attempts = attempts - 1
+                time.sleep(migration_delay)
+            else:
+                raise RuntimeError('Server error')
         except requests.exceptions.ConnectionError:
             if time.time() - start_time > timeout:
                 raise RuntimeError("Timeout: could not connect to the API")
@@ -257,7 +263,7 @@ def get_user_roles_by_name(api, user_role_names):
 
 
 def import_json(
-    api, files, importStrategy="CREATE_AND_UPDATE", mergeMode="MERGE", skipSharing="false"
+        api, files, importStrategy="CREATE_AND_UPDATE", mergeMode="MERGE", skipSharing="false"
 ):
     "Import a json file into DHIS2"
     responses = {}


### PR DESCRIPTION
### :pushpin: References
Issue: http://who-dev.essi.upc.edu:8083/issues/2912
Parent branch: https://github.com/EyeSeeTea/d2-cloner/tree/feature/d2-docker-support

### :tophat: What is the goal?

Avoid crash during the migration to 2.33 when process.py ask for /api/me after relaunch the tomcat with the new war file.


### :memo: How is it being implemented?

I have added attempts and delay in seconds when except requests.exceptions.HTTPError is throw

### :boom: How can it be tested?
run a clone with migration to 2.33 with post-process actions.
