### PR TITLE
Add support for transformed d2 docker

### DIFF
--- a/configuration_example-d2-docker.json
+++ b/configuration_example-d2-docker.json
@@ -1,6 +1,8 @@
 {
     "local_type": "d2-docker",
     "local_docker_image": "eyeseetea/dhis2-data:2.32-training",
+    "local_docker_image_stop_transformed": "eyeseetea/dhis2-data:2.32-training",
+    "_local_docker_image_start_transformed": "eyeseetea/dhis2-data:2.33-training",
     "local_docker_port": 8080,
     "local_docker_deploy_path": "d2",
     "backups_dir": "/home/user/backups",

--- a/dhis2_clone
+++ b/dhis2_clone
@@ -36,17 +36,17 @@ def main():
         sys.exit()
 
     if not args.manual_restart:
-        stop_tomcat(cfg)
+        stop_tomcat(cfg, args)
 
     if not args.no_backups:
-        backup_db(cfg)
+        backup_db(cfg, args)
         backup_war(cfg)
 
     if not args.no_webapps:
         get_webapps(cfg)
 
     if not args.no_db:
-        get_db(cfg)
+        get_db(cfg, args)
 
     if args.post_sql:
         run_sql(cfg, args.post_sql)
@@ -95,6 +95,8 @@ def get_args():
     )
     add("--update-config", action="store_true", help="update the config file")
     add("--no-color", action="store_true", help="don't use colored output")
+    add("--start-transformed", action="store_true", help="Override d2-docker image for start")
+    add("--stop-transformed", action="store_true", help="Override d2-docker image for stop")
     return parser.parse_args()
 
 
@@ -219,6 +221,14 @@ def is_local_d2docker(cfg):
     return server_type == "d2-docker"
 
 
+def get_local_docker_image(cfg, args, action):
+    if action == "start" and args.start_transformed:
+        return cfg["local_docker_image_start_transformed"]
+    elif action == "stop" and args.stop_transformed:
+        return cfg["local_docker_image_stop_transformed"]
+    else:
+        return cfg["local_docker_image"]
+
 def start_tomcat(cfg, args):
     if is_local_tomcat(cfg):
         server_path = cfg["server_dir_local"]
@@ -230,22 +240,22 @@ def start_tomcat(cfg, args):
             return
         run(
             "d2-docker start {} --port={} --detach {}".format(
-                cfg["local_docker_image"],
+                get_local_docker_image(cfg, args, "start"),
                 cfg["local_docker_port"],
                 (("--run-sql '%s'" % post_sql) if post_sql else ""),
             )
         )
 
 
-def stop_tomcat(cfg):
+def stop_tomcat(cfg, args):
     if is_local_tomcat(cfg):
         server_path = cfg["server_dir_local"]
         run('"%s/bin/shutdown.sh"' % server_path)
     elif is_local_d2docker(cfg):
-        run("d2-docker stop {}".format(cfg["local_docker_image"]))
+        run("d2-docker stop {}".format(get_local_docker_image(cfg, args, "stop")))
 
 
-def backup_db(cfg):
+def backup_db(cfg, args):
     backups_dir = cfg["backups_dir"]
     if is_local_tomcat(cfg):
         backup_name = cfg["backup_name"]
@@ -256,7 +266,7 @@ def backup_db(cfg):
             % (backup_file, db_local)
         )
     elif is_local_d2docker(cfg):
-        run("d2-docker copy {} '{}'".format(cfg["local_docker_image"], backups_dir))
+        run("d2-docker copy {} '{}'".format(get_local_docker_image(cfg, args, "stop"), backups_dir))
 
 
 def backup_war(cfg):
@@ -305,7 +315,7 @@ def get_webapps(cfg):
             run("; ".join(commands))
 
 
-def get_db(cfg):
+def get_db(cfg, args):
     "Replace the contents of db_local with db_remote"
     exclude = (
         "--exclude-table 'aggregated*' --exclude-table 'analytics*' "
@@ -328,7 +338,7 @@ def get_db(cfg):
         run(cmd)
         apps_dir = os.path.join(dir_local, "files", "apps")
         d2_docker_cmd = "d2-docker create data {} --sql={} --apps-dir {}".format(
-            cfg["local_docker_image"], sql_path, apps_dir
+            get_local_docker_image(cfg, args, "stop"), sql_path, apps_dir
         )
         run(d2_docker_cmd)
 

--- a/process.py
+++ b/process.py
@@ -105,19 +105,19 @@ def execute(api, entry, cfg, import_dir):
         raise ValueError("Unknown action: %s" % action)
 
 
-def wait_for_server(api, delay=90, timeout=900):
+def wait_for_server(api, timeout=900):
     "Sleep until server is ready to accept requests"
     debug("Check active API: %s" % api.api_url)
-    time.sleep(delay)  # in case tomcat is still starting
     start_time = time.time()
     while True:
         try:
             api.get("/me")
             break
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError) as exc:
+            debug(exc)
             if time.time() - start_time > timeout:
                 raise RuntimeError("Timeout: could not connect to the API")
-            time.sleep(1)
+            time.sleep(10)
 
 
 def select_users(api, usernames, users_from_group_names):

--- a/readme.rst
+++ b/readme.rst
@@ -40,6 +40,8 @@ screen (with color to help identify the steps), and the output of
 those commands too. If any step fails, the program will signal an
 error and stop all the processing at that point.
 
+Instances of type ``d2-docker`` might change its image (typically, in an upgrade) in the cloning process, so there is the concept of "transformed" images. Use options ``--stop-transformed`` to use config entry ``local_docker_image_stop_transformed`` and ``--start-transformed`` to use config entry ``local_docker_image_start_transformed`` instead of the default value ``local_docker_image``.
+
 Setup
 -----
 
@@ -91,6 +93,8 @@ The sections in the configuration file are:
 
 * ``local_type``: Local instance type. "tomcat" or "d2-docker".
 * ``local_docker_image"``. Docker image to use  (example: "eyeseetea/dhis2-data:2.32-sierra-leone").
+* ``local_docker_image_stop_transformed``. If ``--stop-transformed`` options is used, then instead of using ``local_docker_image``, it will use entry ``local_docker_image_stop_transformed``. This "stop" action is then used in the following d2-docker commands: stop_tomcat -> d2-docker stop, backup_db -> d2-docker copy, get_db -> d2-docker create data.
+  "local_docker_image_start_transformed": If ``--start-transformed`` options is used, then instead of using ``local_docker_image``, it will use entry ``local_docker_image_start_transformed``. This "start" action is then used in the following d2-docker commands: start_tomcat -> d2-docker start.
 * ``local_docker_port``: Docker port.
 * ``local_docker_deploy_path``: Docker instance deploy path namespace.
 * ``backups_dir``: directory where it will store the backups.


### PR DESCRIPTION
Closes #4 

How it works:

- We have two new options for `dhis2_clone`: `--start-transformed` and `--stop-transformed`.
- Those options apply only if using `"local_type": "d2-docker"`.
- If option `--stop-transformed` is set, then instead of using `jsonConf->local_docker_image`, it will use `jsonConf->local_docker_image_stop_transformed`. This "stop" action is then used in the following d2-docker commands: stop_tomcat -> d2-docker stop, backup_db -> d2-docker copy, get_db -> d2-docker create data, 
- If option `--start-transformed` is set, then instead of using `jsonConf->local_docker_image`, it will use `jsonConf->local_docker_image_start_transformed`.  This "start" action is then used in the following d2-docker commands: start_tomcat -> d2-docker start.
- Added a simple refactor of `wait_for_server` (follows #3 idea, but more simple)