### PR TITLE
Run d2-docker start --run-scripts for postprocessing scripts

### DIFF
--- a/dhis2_clone
+++ b/dhis2_clone
@@ -198,7 +198,7 @@ def magenta(txt):
 
 
 def execute_scripts(cfg, is_post_tomcat=False):
-    if is_local_d2docker(cfg):
+    if is_local_d2docker(cfg) and not is_post_tomcat:
         # Scripts will be executed at d2-docker start --run-scripts=DIR
         return
     dirname = cfg["post_clone_scripts_dir"]
@@ -243,7 +243,7 @@ def start_tomcat(cfg, args):
         if post_sql and (len(args.post_sql) != 1 or not os.path.isdir(post_sql)):
             log("--post-sql for d2-docker requires a single directory")
             return
-        post_scripts_dir = cfg["post_clone_scripts_dir"]
+        post_scripts_dir = cfg.get("local_docker_post_clone_scripts_dir", None)
         api = cfg["api_local"]
 
         run(
@@ -254,7 +254,7 @@ def start_tomcat(cfg, args):
                 (("--tomcat-server-xml '%s'" % server_xml_path) if server_xml_path else ""),
                 (("--run-sql '%s'" % post_sql) if post_sql else ""),
                 (("--run-scripts '%s'" % post_scripts_dir) if post_scripts_dir else ""),
-                "--auth '%s'" % (api["username"] + ":" + api["password"])
+                (("--auth '%s'" % (api["username"] + ":" + api["password"])) if api else "")
             )
         )
 

--- a/dhis2_clone
+++ b/dhis2_clone
@@ -247,14 +247,14 @@ def start_tomcat(cfg, args):
         api = cfg["api_local"]
 
         run(
-            "d2-docker start {} --port={} --detach {} {} {}".format(
+            "d2-docker start {} --port={} --detach {} {} {} {} {}".format(
                 get_local_docker_image(cfg, args, "start"),
                 cfg["local_docker_port"],
                 (("--deploy-path '%s'" % deploy_path) if deploy_path else ""),
                 (("--tomcat-server-xml '%s'" % server_xml_path) if server_xml_path else ""),
-                "--auth '%s'" % (api["username"] + ":" + api["password"]),
                 (("--run-sql '%s'" % post_sql) if post_sql else ""),
                 (("--run-scripts '%s'" % post_scripts_dir) if post_scripts_dir else ""),
+                "--auth '%s'" % (api["username"] + ":" + api["password"])
             )
         )
 

--- a/dhis2_clone
+++ b/dhis2_clone
@@ -196,6 +196,9 @@ def magenta(txt):
 
 
 def execute_scripts(cfg, is_post_tomcat=False):
+    if is_local_d2docker(cfg):
+        # Scripts will be executed at d2-docker start --run-scripts=DIR
+        return
     dirname = cfg["post_clone_scripts_dir"]
     is_script = lambda fname: os.path.splitext(fname)[-1] in [".sh", ".py"]
     is_normal = lambda fname: not fname.startswith("post")
@@ -228,11 +231,16 @@ def start_tomcat(cfg, args):
         if post_sql and (len(args.post_sql) != 1 or not os.path.isdir(post_sql)):
             log("--post-sql for d2-docker requires a single directory")
             return
+        post_scripts_dir = cfg["post_clone_scripts_dir"]
+        api = cfg["api_local"]
+
         run(
-            "d2-docker start {} --port={} --detach {}".format(
+            "d2-docker start {} --port={} --detach {} {} {}".format(
                 cfg["local_docker_image"],
                 cfg["local_docker_port"],
+                "--auth '%s'" % (api["username"] + ":" + api["password"]),
                 (("--run-sql '%s'" % post_sql) if post_sql else ""),
+                (("--run-scripts '%s'" % post_scripts_dir) if post_scripts_dir else ""),
             )
         )
 

--- a/readme.rst
+++ b/readme.rst
@@ -73,6 +73,7 @@ optional arguments:
                         sql files to run post-clone (pass a folder instead for d2-docker type)
   --post-clone-scripts  execute all py and sh scripts in
                         post_clone_scripts_dir (DHIS2 URL with auth passed as first argument)
+                        or local_docker_post_clone_scripts_dir for local docker.
   --update-config       update the config file
   --no-color            don't use colored output
 


### PR DESCRIPTION
Closes #5 

Requires https://github.com/EyeSeeTea/d2-docker/pull/53

- `execute_scripts` is not used on d2-docker images. Instead, use `d2-docker start --run-scripts=/path/to/scripts --auth=AUTH_FROM_CFG_API_LOCAL`.