### PR TITLE
Support deploy path

### DIFF
--- a/configuration_example-d2-docker.json
+++ b/configuration_example-d2-docker.json
@@ -2,6 +2,7 @@
     "local_type": "d2-docker",
     "local_docker_image": "eyeseetea/dhis2-data:2.32-training",
     "local_docker_port": 8080,
+    "local_docker_deploy_path": "d2",
     "backups_dir": "/home/user/backups",
     "backup_name": "TRAINING",
     "server_dir_local": "/home/user/server",
@@ -10,7 +11,7 @@
     "db_remote": "postgresql://user:pass@server_remote:5432/db",
     "war_remote": "ROOT.war",
     "api_local": {
-        "url": "http://localhost:8080",
+        "url": "http://localhost:8080/d2",
         "username": "system",
         "password": "System123"
     },

--- a/dhis2_clone
+++ b/dhis2_clone
@@ -225,6 +225,7 @@ def start_tomcat(cfg, args):
         run('"%s/bin/startup.sh"' % server_path)
     elif is_local_d2docker(cfg):
         post_sql = args.post_sql[0] if args.post_sql else None
+        deploy_path = cfg.get("local_docker_deploy_path", None)
         if post_sql and (len(args.post_sql) != 1 or not os.path.isdir(post_sql)):
             log("--post-sql for d2-docker requires a single directory")
             return
@@ -232,6 +233,7 @@ def start_tomcat(cfg, args):
             "d2-docker start {} --port={} --detach {}".format(
                 cfg["local_docker_image"],
                 cfg["local_docker_port"],
+                (("--deploy-path '%s'" % deploy_path) if deploy_path else ""),
                 (("--run-sql '%s'" % post_sql) if post_sql else ""),
             )
         )

--- a/dhis2_clone
+++ b/dhis2_clone
@@ -231,7 +231,7 @@ def start_tomcat(cfg, args):
             log("--post-sql for d2-docker requires a single directory")
             return
         run(
-            "d2-docker start {} --port={} --detach {}".format(
+            "d2-docker start {} --port={} --detach {} {} {}".format(
                 cfg["local_docker_image"],
                 cfg["local_docker_port"],
                 (("--deploy-path '%s'" % deploy_path) if deploy_path else ""),

--- a/dhis2_clone
+++ b/dhis2_clone
@@ -226,6 +226,7 @@ def start_tomcat(cfg, args):
     elif is_local_d2docker(cfg):
         post_sql = args.post_sql[0] if args.post_sql else None
         deploy_path = cfg.get("local_docker_deploy_path", None)
+        server_xml_path = cfg.get("local_docker_server_xml", None)
         if post_sql and (len(args.post_sql) != 1 or not os.path.isdir(post_sql)):
             log("--post-sql for d2-docker requires a single directory")
             return
@@ -234,6 +235,7 @@ def start_tomcat(cfg, args):
                 cfg["local_docker_image"],
                 cfg["local_docker_port"],
                 (("--deploy-path '%s'" % deploy_path) if deploy_path else ""),
+                (("--tomcat-server-xml '%s'" % server_xml_path) if server_xml_path else ""),
                 (("--run-sql '%s'" % post_sql) if post_sql else ""),
             )
         )

--- a/readme.rst
+++ b/readme.rst
@@ -89,6 +89,10 @@ An example configuration file is provided in this repository
 
 The sections in the configuration file are:
 
+* ``local_type``: Local instance type. "tomcat" or "d2-docker".
+* ``local_docker_image"``. Docker image to use  (example: "eyeseetea/dhis2-data:2.32-sierra-leone").
+* ``local_docker_port``: Docker port.
+* ``local_docker_deploy_path``: Docker instance deploy path namespace.
 * ``backups_dir``: directory where it will store the backups.
 * ``backup_name``: an identifier that it will append to the name of
   the war file and database backups.


### PR DESCRIPTION
Closes #2 

Requires https://github.com/EyeSeeTea/d2-docker/pull/51

Note to the tester: When adding a deploy path (example: `"local_docker_deploy_path": "dhis2"`), change also "api_local"->"url" (example: "http://localhost:8090/d2").