### PR TITLE
get username if userCredentials not exist

### DIFF
--- a/process.py
+++ b/process.py
@@ -203,7 +203,10 @@ def remove_groups(api, users, groups_to_remove_from):
 
 
 def get_username(user):
-    return user["userCredentials"]["username"]
+    if "userCredentials" in user.keys():
+          return user["userCredentials"]["username"]
+    else:
+          return user["username"]
 
 
 def get_roles(user):


### PR DESCRIPTION
In 2.35 the usergroup api call does not return usercredentials, this PR fixes that call.

example:
preprod-cont 2.35:
https://portal-uat.who.int/dhis2-cont/api/userGroups?filter=name:in:[ADMIN%20reactivate%20after%20cloning]&fields=id,name,users[:all,userCredentials[:all,userRoles[id,name]]]
preprod 2.34:
https://portal-uat.who.int/dhis2/api/userGroups?filter=name:in:[ADMIN%20reactivate%20after%20cloning]&fields=id,name,users[:all,userCredentials[:all,userRoles[id,name]]]