### PR TITLE
Make rsync follow symlinks when copying webapps/files

### DIFF
--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -320,7 +320,7 @@ def get_webapps(cfg):
     route_remote = "%s:%s" % (cfg["hostname_remote"], cfg["server_dir_remote"])
 
     for mandatory, subdir in [[True, "webapps"], [False, "files"]]:
-        cmd = "rsync -avP --delete %s/%s %s" % (route_remote, subdir, route_local)
+        cmd = "rsync -avP -LK --delete %s/%s %s" % (route_remote, subdir, route_local)
         log(cmd)
         p = Popen(
             cmd,


### PR DESCRIPTION
Required by: https://app.clickup.com/t/m387ev

We've found a DHIS2 installation where the `files/` folder lives outside the tomcat root. We can create a symlink but still `rsync` won't copy its contents, just the symlinks. Add `-L -K` options to instruct rsync to follow symlinks and copy its content files.