### PR TITLE
Feature/remove temporal folders

### DIFF
--- a/configuration_example-d2-docker.json
+++ b/configuration_example-d2-docker.json
@@ -10,7 +10,7 @@
   "backup_name": "TRAINING",
   "server_dir_local": "/home/user/server",
   "server_dir_remote": "/home/user/server",
-  "docker_temporal_folder": "/temporal/path",
+  "docker_temp_folder": "/temp/path",
   "hostname_remote": "prod",
   "pre_api": "2.36",
   "post_api": "2.36",

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -170,8 +170,8 @@ def get_args():
     add("--manual-restart", action="store_true", help="don't stop/start tomcat")
     add("--post-sql", nargs="+", default=[], help="sql files to run post-clone")
     add("--strict-sql", action="store_true", help="stop the sql script on first fail and show in the log")
-    add("--pre-api", help="Pre Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
-    add("--post-api", help="Post Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
+    add("--pre-api", help="Pre Api calls compatible versions: 2.34 / 2.36 / 2.38 / 2.41 (default: 2.36)")
+    add("--post-api", help="Post Api calls compatible versions: 2.34 / 2.36 / 2.38 / 2.41 (default: 2.36)")
     add("--keep-temp",  action="store_true", help="Preserve temporary d2-docker files for cloning the instance")
 
     add(

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -348,12 +348,16 @@ def start_tomcat(cfg, args):
         server_xml_path = cfg.get("local_docker_server_xml", None)
         dhis_conf_path = cfg.get("local_docker_dhis_conf", None)
         temporal_folder = cfg.get("docker_temporal_folder", None)
-        if post_sql and (len(args.post_sql) != 1 or not os.path.isdir(post_sql)):
-            log("--post-sql for d2-docker requires a single directory")
-            return
+        if post_sql:
+            if len(args.post_sql) != 1 or not os.path.isdir(post_sql):
+                log("--post-sql for d2-docker requires a single directory")
+                return
+            elif args.strict_sql:
+                add_strict_to_filenames(post_sql)
+
         post_scripts_dir = cfg.get("local_docker_post_clone_scripts_dir", None)
         api_url = cfg["api_local_url"]
-        strict_sql_enabled = args.strict_sql
+
         run(
             "d2-docker {} start {} --port={} --detach {} {} {} {} {} {}".format(
                 (("--temp-directory '%s'" % temporal_folder) if temporal_folder else ""),
@@ -362,34 +366,22 @@ def start_tomcat(cfg, args):
                 (("--deploy-path '%s'" % deploy_path) if deploy_path else ""),
                 (("--tomcat-server-xml '%s'" % server_xml_path) if server_xml_path else ""),
                 (("--dhis-conf '%s'" % dhis_conf_path) if dhis_conf_path else ""),
-                (("--run-sql '%s'%s" % (post_sql, " --strict-sql " if strict_sql_enabled else "")) if post_sql else ""),
+                (("--run-sql '%s'" % post_sql) if post_sql else ""),
                 (("--run-scripts '%s'" % post_scripts_dir) if post_scripts_dir else ""),
                 (("--auth '%s'" % (args.api_local_username + ":" + args.api_local_password)) if api_url else "")
             )
         )
-        if args.post_sql:
-            abort_clone = is_post_sql_execution_valid(cfg["local_docker_image"], "Error detected while executing SQL file: /data/db/post_strict_sql/test.sql")
-            if not abort_clone:
-                log("Error executing post-sql files. aborting...")
-                run(
-                    "d2-docker stop {} ".format(
-                        get_local_docker_image(cfg, args, "start")
-                    )
-                )
-                sys.exit(1)
 
 
-def is_post_sql_execution_valid(container, search_text, interval=15):
-    time.sleep(30) #give some seconds to wait for the d2-docker start
-    while True:
-        log_output = subprocess.getoutput(f"d2-docker logs {container}")
-        if search_text in log_output:
-            print(f"Match: {search_text}")
-            return False
-        elif "[dhis2-core-start] Start Tomcat catalina" in log_output:
-            return True
-        print("Waiting...")
-        time.sleep(interval)
+def add_strict_to_filenames(post_sql):
+    for filename in os.listdir(post_sql):
+        old_path = os.path.join(post_sql, filename)
+        if os.path.isfile(old_path):
+            name, ext = os.path.splitext(filename)
+            new_filename = f"{name}_strict{ext}"
+            new_path = os.path.join(post_sql, new_filename)
+            os.rename(old_path, new_path)
+            log(f"Renamed: {old_path} -> {new_path}")
 
 
 def stop_tomcat(cfg, args):

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -76,7 +76,7 @@ def main():
         execute_scripts(cfg, args)
     if not args.keep_temporal and is_local_d2docker(cfg):
         d2_docker_tmp_dir = cfg["server_dir_local"]
-        #remove temporal files but in tomcat are the real files
+        #Only the d2-docker files are truly temporary files (Tomcat files shouldn't be deleted).
         if os.path.exists(d2_docker_tmp_dir) and os.path.isdir(d2_docker_tmp_dir):
             os.system(f"rm -rf {d2_docker_tmp_dir}/*")
 

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -74,7 +74,7 @@ def main():
 
     if args.post_clone_scripts:
         execute_scripts(cfg, args)
-    if not args.keep_temporal and is_local_d2docker(cfg):
+    if not args.keep_temp and is_local_d2docker(cfg):
         d2_docker_tmp_dir = cfg["server_dir_local"]
         #Only the d2-docker files are truly temporary files (Tomcat files shouldn't be deleted).
         if os.path.exists(d2_docker_tmp_dir) and os.path.isdir(d2_docker_tmp_dir):
@@ -172,7 +172,7 @@ def get_args():
     add("--strict-sql", action="store_true", help="stop the sql script on first fail and show in the log")
     add("--pre-api", help="Pre Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
     add("--post-api", help="Post Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
-    add("--keep-temporal",  action="store_true", help="Preserve temporary d2-docker files for cloning the instance")
+    add("--keep-temp",  action="store_true", help="Preserve temporary d2-docker files for cloning the instance")
 
     add(
         "--post-clone-scripts",
@@ -347,7 +347,7 @@ def start_tomcat(cfg, args):
         deploy_path = cfg.get("local_docker_deploy_path", None)
         server_xml_path = cfg.get("local_docker_server_xml", None)
         dhis_conf_path = cfg.get("local_docker_dhis_conf", None)
-        temporal_folder = cfg.get("docker_temporal_folder", None)
+        temp_folder = cfg.get("docker_temp_folder", None)
         if post_sql:
             if len(args.post_sql) != 1 or not os.path.isdir(post_sql):
                 log("--post-sql for d2-docker requires a single directory")
@@ -360,7 +360,7 @@ def start_tomcat(cfg, args):
 
         run(
             "d2-docker {} start {} --port={} --detach {} {} {} {} {} {}".format(
-                (("--temp-directory '%s'" % temporal_folder) if temporal_folder else ""),
+                (("--temp-directory '%s'" % temp_folder) if temp_folder else ""),
                 get_local_docker_image(cfg, args, "start"),
                 cfg["local_docker_port"],
                 (("--deploy-path '%s'" % deploy_path) if deploy_path else ""),
@@ -482,11 +482,11 @@ def get_db(cfg, args):
         apps_dir = os.path.join(dir_local, "files", "apps")
         documents_dir = os.path.join(dir_local, "files", "document")
         datavalues_dir = os.path.join(dir_local, "files", "dataValue")
-        temporal_folder = cfg.get("docker_temporal_folder", None)
+        temp_folder = cfg.get("docker_temp_folder", None)
 
         run(
             "d2-docker {} create data {} --sql={} {} {} {}".format(
-                (("--temp-directory '%s'" % temporal_folder) if temporal_folder else ""),
+                (("--temp-directory '%s'" % temp_folder) if temp_folder else ""),
                 get_local_docker_image(cfg, args, "stop"),
                 sql_path,
                 (("--apps-dir '%s'" % apps_dir) if os.path.isdir(apps_dir) else ""),

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -173,7 +173,6 @@ def get_args():
     add("--pre-api", help="Pre Api calls compatible versions: 2.34 / 2.36 / 2.38 / 2.41 (default: 2.36)")
     add("--post-api", help="Post Api calls compatible versions: 2.34 / 2.36 / 2.38 / 2.41 (default: 2.36)")
     add("--keep-temp",  action="store_true", help="Preserve temporary d2-docker files for cloning the instance")
-
     add(
         "--post-clone-scripts",
         action="store_true",

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -74,6 +74,12 @@ def main():
 
     if args.post_clone_scripts:
         execute_scripts(cfg, args)
+    if not args.keep_temporal and is_local_d2docker(cfg):
+        d2_docker_tmp_dir = cfg["server_dir_local"]
+        #remove temporal files but in tomcat are the real files
+        if os.path.exists(d2_docker_tmp_dir) and os.path.isdir(d2_docker_tmp_dir):
+            os.system(f"rm -rf {d2_docker_tmp_dir}/*")
+
 
     if not args.manual_restart:
         start_tomcat(cfg, args)
@@ -166,6 +172,8 @@ def get_args():
     add("--strict-sql", action="store_true", help="stop the sql script on first fail and show in the log")
     add("--pre-api", help="Pre Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
     add("--post-api", help="Post Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
+    add("--keep-temporal", help="Preserve temporary d2-docker files for cloning the instance")
+
     add(
         "--post-clone-scripts",
         action="store_true",

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -172,7 +172,7 @@ def get_args():
     add("--strict-sql", action="store_true", help="stop the sql script on first fail and show in the log")
     add("--pre-api", help="Pre Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
     add("--post-api", help="Post Api calls compatible versions: 2.34 / 2.36 (default: 2.36)")
-    add("--keep-temporal", help="Preserve temporary d2-docker files for cloning the instance")
+    add("--keep-temporal",  action="store_true", help="Preserve temporary d2-docker files for cloning the instance")
 
     add(
         "--post-clone-scripts",

--- a/readme.rst
+++ b/readme.rst
@@ -44,39 +44,52 @@ Instances of type ``d2-docker`` might change its image (typically, in an upgrade
 
 Setup
 -----
+.. code-block:: bash
 
-  $ sudo apt install pip3
-  $ pip install -r requirements.txt
+  sudo apt install pip3
+  pip install -r requirements.txt
 
 Usage
 -----
+.. code-block:: bash
 
-  usage: dhis2_clone [-h] [--no-backups] [--no-webapps] [--no-db]
-                   [--no-postprocess] [--manual-restart]
-                   [--post-sql POST_SQL [POST_SQL ...]] [--post-clone-scripts]
-                   [--update-config] [--no-color]
-                   CONFIG_FILE
+  dhis2_clone.py [-h] [--db-local DB_LOCAL] [--db-remote DB_REMOTE] [--api-local-username API_LOCAL_USERNAME]
+                      [--api-local-password API_LOCAL_PASSWORD] [--no-backups] [--no-webapps] [--no-db]
+                      [--no-postprocess] [--no-preprocess] [--manual-restart] [--post-sql POST_SQL [POST_SQL ...]]
+                      [--strict-sql] [--pre-api PRE_API] [--post-api POST_API] [--keep-temp] [--post-clone-scripts]
+                      [--post-import] [--update-config] [--no-color] [--start-transformed] [--stop-transformed]
+                      [--use-backup USE_BACKUP]
+                      config
 
-Clone a dhis2 installation from another server.
+positional arguments::
 
-positional arguments:
-  config                file with configuration
+  config                                   file with configuration
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --no-backups          don't make backups
-  --no-webapps          don't clone the webapps
-  --no-db               don't clone the database
-  --no-postprocess      don't do postprocessing
-  --manual-restart      don't stop/start tomcat
-  --post-sql POST_SQL [POST_SQL ...]
-                        sql files to run post-clone (pass a folder instead for d2-docker type)
-  --post-clone-scripts  execute all py and sh scripts in
-                        post_clone_scripts_dir (DHIS2 URL with auth passed as first argument)
-                        or local_docker_post_clone_scripts_dir for local docker.
-  --update-config       update the config file
-  --no-color            don't use colored output
-  --use-backup          Path to remote backup file to use instead of making a remote pg_dump
+options::
+
+  -h, --help                               show this help message and exit
+  --db-local DB_LOCAL                      db to be override
+  --db-remote DB_REMOTE                    db to be copied in the db-local
+  --api-local-username API_LOCAL_USERNAME  api local user
+  --api-local-password API_LOCAL_PASSWORD  api local password
+  --no-backups                             don't make backups
+  --no-webapps                             don't clone the webapps
+  --no-db                                  don't clone the database
+  --no-postprocess                         don't do postprocessing
+  --no-preprocess                          don't do preprocessing
+  --manual-restart                         don't stop/start tomcat
+  --post-sql POST_SQL [POST_SQL ...]       sql files to run post-clone
+  --strict-sql                             stop the sql script on first fail and show in the log
+  --pre-api PRE_API                        Pre Api calls compatible versions: 2.34 / 2.36 / 2.38 / 2.41 (default: 2.36)
+  --post-api POST_API                      Post Api calls compatible versions: 2.34 / 2.36 / 2.38 / 2.41 (default: 2.36)
+  --keep-temp                              Preserve temporary d2-docker files for cloning the instance
+  --post-clone-scripts                     execute all py and sh scripts in post_clone_scripts_dir
+  --post-import                            import to DHIS2 selected json files from post_process_import_dir
+  --update-config                          update the config file
+  --no-color                               don't use colored output
+  --start-transformed                      Override d2-docker image for start
+  --stop-transformed                       Override d2-docker image for stop
+  --use-backup USE_BACKUP                  Path to remote backup file to use instead of making a remote pg_dump
 
 
 Configuration
@@ -84,7 +97,7 @@ Configuration
 
 To invoke the program you need to specify a configuration file, as in::
 
-  $ dhis2_clone config_training.json
+  dhis2_clone config_training.json
 
 An example configuration file is provided in this repository
 (`configuration_example.json`_).
@@ -216,9 +229,11 @@ Automatic cloning
 -----------------
 
 You may want to run the cloning script periodically. For that, you can
-use the appropriate users's crontab::
+use the appropriate users's crontab:
 
-  $ crontab -e
+.. code-block:: bash
+
+  crontab -e
 
 For example, this will run the cloning for a training server every
 Saturday night at 22:00::

--- a/readme.rst
+++ b/readme.rst
@@ -102,8 +102,8 @@ The sections in the configuration file are:
 * ``backups_dir``: directory where it will store the backups.
 * ``backup_name``: an identifier that it will append to the name of
   the war file and database backups.
-* ``server_dir_local``: base directory of the tomcat running in the
-  local server.
+* ``server_dir_local``: base directory of the tomcat running in the local server. Although server_dir_local points to the Tomcat base directory, it is also used internally as a temporary directory by d2-docker. When running a d2-docker cloning operation, this temporary directory will be removed by default (unless you use the --keep-temp option).
+If this path is set to a critical location (such as your home directory or any folder with important files), you risk losing data. Only the d2-docker temporary files are intended to be removed, but the behavior can be misleading.
 * ``server_dir_remote``: base directory of the tomcat running in the
   remote server.
 * ``hostname_remote``: name or IP of the machine containing the remote

--- a/readme.rst
+++ b/readme.rst
@@ -116,7 +116,7 @@ The sections in the configuration file are:
   example, if it is ``dhis2-demo.war``, the webserver will respond at
   ``https://.../dhis2-demo``).
 * ``war_remote``: name of the remote war file.
-* ``docker_temporal_folder``: Base folder for the docker creation temporal folders.
+* ``docker_temp_folder``: Base folder for the docker creation temp folders.
 * ``api_local``: if some post-processing steps are applied, this
   section needs to define as params the username and password ``url``, ``username`` and ``password`` to
   connect to the running DHIS2 system after the cloning.


### PR DESCRIPTION
@nshandra not review this PR now, we need approve first
https://github.com/EyeSeeTea/d2-cloner/pull/55


This PR updates d2-cloner to automatically delete temporary folders by default after execution. Previously, these folders were retained unless manually removed.

Added --keep-temporal option to retain temporary folders if needed.