### PR TITLE
Bug/fix strict minus issues

### DIFF
--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -374,12 +374,14 @@ def start_tomcat(cfg, args):
 
 def add_strict_to_filenames(post_sql):
     for filename in os.listdir(post_sql):
+        if '_strict' in filename:
+            continue
         old_path = os.path.join(post_sql, filename)
         if os.path.isfile(old_path):
             name, ext = os.path.splitext(filename)
             new_filename = f"{name}_strict{ext}"
             new_path = os.path.join(post_sql, new_filename)
-            os.rename(old_path, new_path)
+            os.replace(old_path, new_path)
             log(f"Renamed: {old_path} -> {new_path}")
 
 

--- a/src/preprocess/sql_generation/queries/delete_trackers.py
+++ b/src/preprocess/sql_generation/queries/delete_trackers.py
@@ -85,6 +85,7 @@ def delete_all_tracker_programs_from_lists(trackers, f):
 
 def delete_all_tracker_programs(trackers, f):
     write(f, """
+        DROP MATERIALIZED VIEW IF EXISTS tei_to_remove;
         create MATERIALIZED view tei_to_remove as select {trackedentityinstanceid} "teiid"
         from {programinstance} where programid in (select programid from program where uid in {tracker_uids});
     """.format(trackedentityinstanceid=get_enrollment_identifier_name(),
@@ -155,7 +156,7 @@ def delete_all_tracker_programs(trackers, f):
         DELETE FROM trackedentityattributevalue where {trackedentityinstanceid} in ( select * from tei_to_remove);
         DELETE FROM trackedentityprogramowner where {trackedentityinstanceid} in ( select * from tei_to_remove);
         DELETE FROM {trackedentityinstance} where {trackedentityinstanceid} in ( select * from tei_to_remove);
-        DROP MATERIALIZED view tei_to_remove ;
+        DROP MATERIALIZED VIEW IF EXISTS tei_to_remove;
         --remove tracker finish
     """.format(programinstance=get_enrollment_table_name(), trackedentityinstance=get_tracker_table_name(),
                trackedentityinstanceid=get_tracker_identifier_name()))


### PR DESCRIPTION
Prevents generating multiple renamed files (e.g., file_strict_strict.sql) by ensuring _strict is only appended once to filenames.
Avoids errors by safely dropping a materialized view only if it exists.



