### PR TITLE
feature/selective rsync

### DIFF
--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -422,7 +422,7 @@ def get_webapps(cfg):
     route_local = cfg["server_dir_local"]
     route_remote = "%s:%s" % (cfg["hostname_remote"], cfg["server_dir_remote"])
 
-    for mandatory, subdir in [[True, "webapps"], [False, "files/apps"], [False, "files/documents"], [False, "files/dataValue"]]:
+    for mandatory, subdir in [[True, "webapps"], [False, "files/apps"], [False, "files/document"], [False, "files/dataValue"]]:
         cmd = "rsync -avP -LK --delete --relative %s/./%s %s" % (route_remote, subdir, route_local)
         log(cmd)
         p = Popen(

--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -422,8 +422,8 @@ def get_webapps(cfg):
     route_local = cfg["server_dir_local"]
     route_remote = "%s:%s" % (cfg["hostname_remote"], cfg["server_dir_remote"])
 
-    for mandatory, subdir in [[True, "webapps"], [False, "files"]]:
-        cmd = "rsync -avP -LK --delete %s/%s %s" % (route_remote, subdir, route_local)
+    for mandatory, subdir in [[True, "webapps"], [False, "files/apps"], [False, "files/documents"], [False, "files/dataValue"]]:
+        cmd = "rsync -avP -LK --delete --relative %s/./%s %s" % (route_remote, subdir, route_local)
         log(cmd)
         p = Popen(
             cmd,


### PR DESCRIPTION
This PR modifies the list of subdirs to Rsync from remote to local to avoid copying additional folders that we do not use later to create the docker image, reducing the time to perform the rsync and the temporal space it uses.
Since subfolders are referenced, to avoid moving those one level up in the destination, `--relative` is used, including a `./` indicator to rsync to where it should base the relative path. Note that this requires rsync v2.6.7 or later, which dates March 2006, so it is safe to assume that it will be available.