### PR TITLE
Remove new relations corner case for tracker-events

### DIFF
--- a/src/preprocess/sql_generation/queries/delete_trackers.py
+++ b/src/preprocess/sql_generation/queries/delete_trackers.py
@@ -137,6 +137,14 @@ def delete_all_tracker_programs(trackers, f):
     """.format(programstageinstance=get_event_table_name(),
                                               programstageinstanceid=get_event_identifier_name(),
                                               tracker_uids=trackers))
+
+    write(f,"""
+        DELETE FROM {programstageinstance} where {programinstanceid} in (select {programinstanceid} from {programinstance}  
+        where programstageid in (select programstageid from programstage where programid in (select programid 
+        from program where uid in {tracker_uids})));\n
+    """.format(programstageinstance=get_event_table_name(), programinstanceid= get_enrollment_identifier_name(),
+               programinstance=get_enrollment_table_name(),tracker_uids=trackers))
+
     write(f,"""
             DELETE FROM {programinstancecomments} 
             where {programinstanceid} in (select {programinstanceid} from {programinstance} 
@@ -150,6 +158,14 @@ def delete_all_tracker_programs(trackers, f):
         DELETE FROM {programinstance} 
         where programid in (select programid from program where uid in {tracker_uids});\n
     """.format(programinstance=get_enrollment_table_name(),tracker_uids=trackers))
+
+    write(f, """
+        delete from trackedentitydatavalueaudit where {programstageinstanceid} in (select {programstageinstanceid} from {programstageinstance} where {programinstanceid} in (select {programinstanceid} FROM {programinstance} where {trackedentityinstanceid} in ( select * from tei_to_remove)));
+        delete from {programstageinstance} where {programinstanceid} in (select {programinstanceid} FROM {programinstance} where {trackedentityinstanceid} in ( select * from tei_to_remove));"""
+          .format(programstageinstance=get_event_table_name(), programstageinstanceid=get_event_identifier_name(),
+                  programinstanceid=get_enrollment_identifier_name(), programinstance=get_enrollment_table_name(),
+                  trackedentityinstance=get_tracker_table_name(),
+               trackedentityinstanceid=get_tracker_identifier_name()))
 
     write(f, """
         DELETE FROM {programinstance} where {trackedentityinstanceid} in ( select * from tei_to_remove);


### PR DESCRIPTION
New relationships have been introduced in the database schema that trigger constraint violations during deletions. To address this, I reviewed and added the following SQL statements to ensure that no constraint errors are raised during the deletion process.

These changes are already deployed in services. We can consider the functional testing as completed.