### PR TITLE
Fix startup missing table aggregatedataexchange on tomcat startup in …

### DIFF
--- a/dhis2_clone.py
+++ b/dhis2_clone.py
@@ -456,8 +456,8 @@ def get_webapps(cfg):
 def get_db(cfg, args):
     "Replace the contents of db_local with db_remote"
     exclude = (
-        "--exclude-table 'aggregated*' --exclude-table 'analytics*' "
-        "--exclude-table 'completeness*' --exclude-schema sys"
+        " --exclude-table 'analytics*' --exclude-table 'completeness*' "
+        " --exclude-schema sys "
     )
     dir_local = cfg["server_dir_local"]
 


### PR DESCRIPTION
We removed the exclusion of aggregate* tables from the database copy because aggregatedataexchange is now required at DHIS2 startup in recent versions. 
Without it, the application throws an exception.

Currently, this table is empty in our environment, but in other contexts, it might contain relevant data, so it makes more sense to include it rather than exclude it by default.

We didn't find any other tables starting with aggregate in our environment. 
Perhaps such tables existed in previous versions, but they are no longer present.

