### PR TITLE
fix error deleting event program enrollments due are mandatory in eve…

### DIFF
--- a/src/preprocess/sql_generation/queries/delete_programs.py
+++ b/src/preprocess/sql_generation/queries/delete_programs.py
@@ -86,9 +86,8 @@ def delete_all_event_programs_from_lists(programs, f):
 def create_index_to_improve_deletion(f):
     write(f, """
         CREATE INDEX IF NOT EXISTS idx_events_to_remove ON events_to_remove ({eventid});
-        CREATE INDEX IF NOT EXISTS idx_enrollments_to_remove ON enrollments_to_remove ({enrollmentid});
     """.format(trackedentityid=get_tracker_identifier_name(), event=get_event_table_name(),
-               eventid=get_event_identifier_name(),enrollmentid=get_enrollment_identifier_name()))
+               eventid=get_event_identifier_name()))
 
 def delete_all_event_programs(programs, f):
     write(f, f"""
@@ -104,20 +103,9 @@ def delete_all_event_programs(programs, f):
                     (SELECT programid FROM program where uid in {programs})
                 );
         """.format(event=get_event_table_name(), eventid=get_event_identifier_name(),programs=programs))
-
-    write(f, """
-            DROP MATERIALIZED VIEW IF EXISTS enrollments_to_remove;
-            CREATE MATERIALIZED VIEW enrollments_to_remove AS
-                SELECT e.{enrollmentid}
-                FROM {enrollment} e
-                WHERE e.programid IN (SELECT programid FROM program where uid in {programs});
-        """.format(enrollmentid=get_enrollment_identifier_name(), enrollment=get_enrollment_table_name(), programs=programs))
     create_index_to_improve_deletion(f)
-
-
     write(f, """
       SELECT 'Events to be deleted: ' || COUNT(*)::text AS D2_DOCKER_PRESQL_SCRIPT FROM events_to_remove;
-      SELECT 'Enrollments to be deleted: ' || COUNT(*)::text as D2_DOCKER_PRESQL_SCRIPT FROM enrollments_to_remove;
     """)
     #remove event audit values
     write(f, "SELECT 'Deleting trackedentitydatavalueaudit....' AS D2_DOCKER_PRESQL_SCRIPT;\n")
@@ -145,29 +133,8 @@ def delete_all_event_programs(programs, f):
         --end remove events block
     """.format(eventid=get_event_identifier_name(),
            event=get_event_table_name(), programs=programs))
-
-    # Remove enrollment_comment in programs.
-    write(f, "SELECT 'Deleting enrollment_comment....' AS D2_DOCKER_PRESQL_SCRIPT;\n")
-    write(f, """
-        DELETE FROM {enrollment_comment}
-        WHERE {enrollmentid} IN (select {enrollmentid} FROM enrollments_to_remove);
-    """.format(
-        enrollment_comment=get_enrollment_comment_table(),
-        enrollmentid=get_enrollment_identifier_name(),
-    ))
-
-    # Remove enrollment in programs.
-    write(f, "SELECT 'Deleting enrollment....' AS D2_DOCKER_PRESQL_SCRIPT;\n")
-    write(f, """
-        DELETE FROM {enrollment} e
-        WHERE {enrollmentid} IN (select {enrollmentid} FROM enrollments_to_remove);
-    """.format(
-        enrollment=get_enrollment_table_name(),
-        enrollmentid=get_enrollment_identifier_name()
-    ))
     write(f, """
         DROP MATERIALIZED VIEW IF EXISTS events_to_remove;
-        DROP MATERIALIZED VIEW IF EXISTS enrollments_to_remove;
     """)
     write(f, f"""
     SELECT 'Close DELETE EVENT PROGRAMS Block' AS D2_DOCKER_PRESQL_SCRIPT;

--- a/src/preprocess/sql_generation/queries/delete_trackers.py
+++ b/src/preprocess/sql_generation/queries/delete_trackers.py
@@ -155,7 +155,8 @@ def delete_all_tracker_programs(trackers, f, exclude=False):
             CREATE MATERIALIZED VIEW enrollments_to_remove AS
                 SELECT e.{enrollmentid}
                 FROM {enrollment} e
-                WHERE e.programid IN (SELECT programid FROM programs_to_remove)
+                WHERE e.programid IN (SELECT programid FROM programs_to_remove) 
+                and e.programid in (select programid from program where type = 'WITH_REGISTRATION')
                 UNION
                 SELECT e.{enrollmentid}
                 FROM {enrollment} e


### PR DESCRIPTION
…nt programs

Reverts an unintended change: we no longer delete enrollments when removing events from Event Programs. Enrollments are required for these programs to function correctly and for saving new events.