### PR TITLE
Feature/better fail detection on previous run

### DIFF
--- a/src/preprocess/sql_generation/queries/delete_orgunits.py
+++ b/src/preprocess/sql_generation/queries/delete_orgunits.py
@@ -86,7 +86,14 @@ def delete_org_unit_data_and_views(f):
         DELETE FROM minmaxdataelement WHERE sourceid in (select * from orgUnitsToDelete);
         DELETE FROM visualization_organisationunits WHERE organisationunitid in (select * from orgUnitsToDelete);
         DELETE FROM organisationunit WHERE organisationunitid in (select * from orgUnitsToDelete);
-        DROP MATERIALIZED VIEW if exists orgUnitsToDelete CASCADE;
+        DROP MATERIALIZED VIEW IF EXISTS rm_programmessage;
+        DROP MATERIALIZED VIEW IF EXISTS rm_interpretation;
+        DROP MATERIALIZED VIEW IF EXISTS rm_event;
+        DROP MATERIALIZED VIEW IF EXISTS rm_event_enrollment;
+        DROP MATERIALIZED VIEW IF EXISTS rm_event_orgs;
+        DROP MATERIALIZED VIEW IF EXISTS rm_enrollment;
+        DROP MATERIALIZED VIEW IF EXISTS rm_trackedentity;
+        DROP MATERIALIZED VIEW IF EXISTS orgUnitsToDelete;
     """)
 
     write(f, f"""

--- a/src/preprocess/sql_generation/queries/delete_orgunits.py
+++ b/src/preprocess/sql_generation/queries/delete_orgunits.py
@@ -101,9 +101,15 @@ def delete_org_units(f):
 
 
 def start_ou_materialized_view(f):
+    # Fail if residual materialized views exist from a previous failed execution.
     write(f, """
-        --remove organisationUnits -- org unit
-        DROP MATERIALIZED VIEW if exists orgUnitsToDelete CASCADE;
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_matviews WHERE matviewname IN ('orgunitstodelete', 'rm_trackedentity', 'rm_enrollment', 'rm_event_orgs', 'rm_event_enrollment', 'rm_event', 'rm_interpretation', 'rm_programmessage')) THEN
+                RAISE EXCEPTION 'Residual materialized views detected (orgUnitsToDelete, rm_trackedentity, etc). A previous deletion execution failed before cleanup. The database may contain data that should have been deleted. Manual intervention is required.';
+            END IF;
+        END
+        $$;
     """)
 
     write(f, """

--- a/src/preprocess/sql_generation/queries/delete_programs.py
+++ b/src/preprocess/sql_generation/queries/delete_programs.py
@@ -94,8 +94,17 @@ def delete_all_event_programs(programs, f):
     SELECT 'Starting DELETE block for eventPrograms All: '
            || quote_literal($${programs or 'NO_IDS'}$$) AS D2_DOCKER_PRESQL_SCRIPT;
     """)
+    # Fail if residual materialized views exist from a previous failed execution.
     write(f, """
-            DROP MATERIALIZED VIEW IF EXISTS events_to_remove;
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_matviews WHERE matviewname = 'events_to_remove') THEN
+                RAISE EXCEPTION 'Residual materialized view events_to_remove detected. A previous deletion execution failed before cleanup. The database may contain data that should have been deleted. Manual intervention is required.';
+            END IF;
+        END
+        $$;
+    """)
+    write(f, """
             CREATE MATERIALIZED VIEW events_to_remove AS
             select e.{eventid}  from {event} e
             where e.programstageid in 

--- a/src/preprocess/sql_generation/queries/delete_trackers.py
+++ b/src/preprocess/sql_generation/queries/delete_trackers.py
@@ -136,8 +136,18 @@ def delete_all_tracker_programs(trackers, f, exclude=False):
         return
 
     #Careful: since the NOT IN operator is applied in the following queries, the initial one must be an IN for all cases.
+    # Fail if residual materialized views exist from a previous failed execution.
+    # Their presence means the previous deletion did not complete and data may not have been properly removed.
     write(f, """
-        DROP MATERIALIZED VIEW IF EXISTS tei_to_remove;
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_matviews WHERE matviewname IN ('tei_to_remove', 'enrollments_to_remove', 'events_to_remove', 'programs_to_remove')) THEN
+                RAISE EXCEPTION 'Residual materialized views detected (tei_to_remove, enrollments_to_remove, etc). A previous deletion execution failed before cleanup. The database may contain data that should have been deleted. Manual intervention is required.';
+            END IF;
+        END
+        $$;
+    """)
+    write(f, """
         create MATERIALIZED view tei_to_remove as select DISTINCT {trackedentityid} as "trackedentityid"
         from {enrollment} where programid in (select programid from program where uid {operator} {tracker_uids}) 
         and {trackedentityid} is not null ;
@@ -145,13 +155,11 @@ def delete_all_tracker_programs(trackers, f, exclude=False):
                enrollment=get_enrollment_table_name(),
                tracker_uids=trackers, operator=operator))
     write(f, """
-        DROP MATERIALIZED VIEW IF EXISTS programs_to_remove;
         create MATERIALIZED view programs_to_remove as (select programid from program where uid {operator} {tracker_uids});
         
     """.format(tracker_uids=trackers, operator=operator))
     # Group all enrollments to be removed from the target programs, plus events in enrollments of tracked entities within those programs
     write(f, """
-            DROP MATERIALIZED VIEW IF EXISTS enrollments_to_remove;
             CREATE MATERIALIZED VIEW enrollments_to_remove AS
                 SELECT e.{enrollmentid}
                 FROM {enrollment} e
@@ -164,7 +172,6 @@ def delete_all_tracker_programs(trackers, f, exclude=False):
         """.format(enrollmentid=get_enrollment_identifier_name(), enrollment=get_enrollment_table_name(), trackedentityid=get_tracker_identifier_name()))
     # Group all events to be removed from the target programs, plus events in enrollments of tracked entities within those programs
     write(f, """
-            DROP MATERIALIZED VIEW IF EXISTS events_to_remove;
             CREATE MATERIALIZED VIEW events_to_remove AS
                 SELECT e.{eventid}
                 FROM {event} e


### PR DESCRIPTION
…ore failed, and we need throw a raise exception

This PR is an attempt to improve error detection during the setup process.

If an execution fails midway, the materialized views are not dropped. If the process is restarted and d2-cloner is in strict mode, it will now detect these residual tables, throw an error, and halt the startup as intended.

Problem:
On some clones, we perform data deletion after cloning. If a query fails, the instance shuts down. If the process is restarted from scratch by f.e. human error, some dependencies might have changed due to the previous interruption. This could result in incomplete data deletion.

Solution:
If the cleanup materialized views already exist at startup, it means a previous execution failed. To prevent data inconsistency, we now raise an exception and stop the process immediately instead of continuing.
Additionally, this improves performance runnin and detecting cloning errors by ensuring we don't trigger slow, redundant deletion processes on inconsistent data.